### PR TITLE
don't walk through empty dirs

### DIFF
--- a/lib/Dist/Inktly/Minty.pm
+++ b/lib/Dist/Inktly/Minty.pm
@@ -177,6 +177,8 @@ sub create_author_tests
 		for grep { m#^xt/# } $self->_get_template_names;
 	
 	my $xtdir = path("~/perl5/xt");
+	return unless $xtdir->exists;
+
 	$self->_file("xt/" . $_->relative($xtdir))->spew_utf8(scalar $_->slurp)
 		for grep { $_ =~ /\.t$/ } $xtdir->children;
 	


### PR DESCRIPTION
...otherwise you'd get

```
Using Dist::Inktly::Minty to create Foo::Bar...
Error opendir on '/home/sromanov/perl5/xt': No such file or directory at /home/sromanov/perl5/perlbrew/perls/perl-5.10.1/lib/site_perl/5.10.1/Dist/Inktly/Minty.pm line 181.
```
