### PR TITLE
use `Simple` profile for default minting

### DIFF
--- a/lib/Dist/Inktly/Minty.pm
+++ b/lib/Dist/Inktly/Minty.pm
@@ -305,9 +305,9 @@ MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 COMMENCE dist.ini
 ;;class='Dist::Inkt::Profile::Simple'
 ;;name='{$dist_name}'
-;;abstract='a distribution that does something-or-other'
+;;abstract='{$abstract}'
 ;;author=['{$author->{name}}']
-;;license=['perl_5']
+;;license=['{$licence->meta2_name}']
 
 COMMENCE meta/changes.pret
 # This file acts as the project's changelog.

--- a/lib/Dist/Inktly/Minty.pm
+++ b/lib/Dist/Inktly/Minty.pm
@@ -303,8 +303,11 @@ WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 
 COMMENCE dist.ini
-;;class='Dist::Inkt::Profile::{uc $author->{cpanid}}'
+;;class='Dist::Inkt::Profile::Simple'
 ;;name='{$dist_name}'
+;;abstract='a distribution that does something-or-other'
+;;author=['{$author->{name}}']
+;;license=['perl_5']
 
 COMMENCE meta/changes.pret
 # This file acts as the project's changelog.


### PR DESCRIPTION
This would guarantee a lower entry barrier for new users to play with `Dist::Inkt*` family:
- no need to create `DI::Profile::CPANID`
- run `distinkt-dist` right away
