### PR TITLE
don't double-encode minted files

### DIFF
--- a/lib/Dist/Inktly/Minty.pm
+++ b/lib/Dist/Inktly/Minty.pm
@@ -142,21 +142,21 @@ sub set_defaults
 sub create_module
 {
 	my $self = shift;
-	$self->_file( $self->{module_filename} )->spew_utf8( $self->_fill_in_template('module') );
+	$self->_file( $self->{module_filename} )->spew( $self->_fill_in_template('module') );
 	return;
 }
 
 sub create_dist_ini
 {
 	my $self = shift;
-	$self->_file('dist.ini')->spew_utf8($self->_fill_in_template('dist.ini'));
+	$self->_file('dist.ini')->spew($self->_fill_in_template('dist.ini'));
 	return;
 }
 
 sub create_metadata
 {
 	my $self = shift;
-	$self->_file($_)->spew_utf8($self->_fill_in_template($_))
+	$self->_file($_)->spew($self->_fill_in_template($_))
 		for grep { m#^meta/# } $self->_get_template_names;
 	return;
 }
@@ -164,7 +164,7 @@ sub create_metadata
 sub create_tests
 {
 	my $self = shift;
-	$self->_file($_)->spew_utf8($self->_fill_in_template($_))
+	$self->_file($_)->spew($self->_fill_in_template($_))
 		for grep { m#^t/# } $self->_get_template_names;
 	return;
 }
@@ -173,13 +173,13 @@ sub create_author_tests
 {
 	my $self = shift;
 	
-	$self->_file($_)->spew_utf8($self->_fill_in_template($_))
+	$self->_file($_)->spew($self->_fill_in_template($_))
 		for grep { m#^xt/# } $self->_get_template_names;
 	
 	my $xtdir = path("~/perl5/xt");
 	return unless $xtdir->exists;
 
-	$self->_file("xt/" . $_->relative($xtdir))->spew_utf8(scalar $_->slurp)
+	$self->_file("xt/" . $_->relative($xtdir))->spew(scalar $_->slurp)
 		for grep { $_ =~ /\.t$/ } $xtdir->children;
 	
 	return;


### PR DESCRIPTION
otherwise we get them mojibake'd (e.g. when I have valid UTF-8 files in my tests under ~/perl5/xt/)
